### PR TITLE
CUS-950 | Add scroll support to companies

### DIFF
--- a/intercom/scroll_collection_proxy.py
+++ b/intercom/scroll_collection_proxy.py
@@ -14,6 +14,9 @@ class ScrollCollectionProxy(six.Iterator):
         # resource name
         self.resource_name = resource_name
 
+        # key name of resource list
+        self.resource_key = "data"
+
         # resource class
         self.resource_class = resource_class
 
@@ -76,14 +79,14 @@ class ScrollCollectionProxy(six.Iterator):
             raise HttpError('Http Error - No response entity returned')
 
         # create the resource iterator
-        collection = response[self.resource_name]
+        collection = response[self.resource_key]
         self.resources = iter(collection)
         # grab the next page URL if one exists
         self.scroll_param = self.extract_scroll_param(response)
 
     def records_present(self, response):
         """Return whether there are resources in the response."""
-        return len(response.get(self.resource_name)) > 0
+        return len(response.get(self.resource_key)) > 0
 
     def extract_scroll_param(self, response):
         """Extract the scroll_param from the response."""

--- a/intercom/service/company.py
+++ b/intercom/service/company.py
@@ -7,12 +7,13 @@ from intercom.api_operations.find import Find
 from intercom.api_operations.find_all import FindAll
 from intercom.api_operations.save import Save
 from intercom.api_operations.load import Load
+from intercom.api_operations.scroll import Scroll
 from intercom.extended_api_operations.users import Users
 from intercom.extended_api_operations.tags import Tags
 from intercom.service.base_service import BaseService
 
 
-class Company(BaseService, All, Delete, Find, FindAll, Save, Load, Users, Tags):
+class Company(BaseService, All, Delete, Find, FindAll, Save, Load, Users, Tags, Scroll):
 
     @property
     def collection_class(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 certifi
 inflection==0.5.0
 pytz==2020.1
-requests==2.24.0
+requests==2.25.0
 urllib3==1.26.5
 six==1.15.0


### PR DESCRIPTION
> JIRA Ticket URL: https://linear.app/twingate/issue/CUS-950/update-python-intercom-to-support-scroll-on-companies
> Notion spec URL: N/A

## Changes 
- Fix `ScrollCollectionProxy` to use current version ([2.8](https://developers.intercom.com/intercom-api-reference/v2.8/reference/listallcompanies)) of the response schema
  - List of companies is now keyed by `"data"` instead of `"companies"`
- Add `Scroll` mixin to `Company`
  - This will allow the creation of a scroll iterator (ex. `for company in intercom.companies.scroll()`)
- Bump `requests` version
  - Previous version has a conflict with the version of `urllib3` specified in `requirements.txt`
